### PR TITLE
Polaris 2

### DIFF
--- a/KirokuG2/kirokug2-database/proc/usp_KirokuG2_Metric_Insert.sql
+++ b/KirokuG2/kirokug2-database/proc/usp_KirokuG2_Metric_Insert.sql
@@ -5,9 +5,8 @@ CREATE PROCEDURE [dbo].[usp_KirokuG2_Metric_Insert]
 ,@nvc_source nvarchar(50)
 ,@nvc_function nvarchar(50)
 ,@i_type int
-,@nvc_key nvarchar(20)
-,@nvc_value nvarchar(20)
-
+,@nvc_key nvarchar(50)
+,@d_value decimal(10,2)
 
 AS
 
@@ -20,7 +19,7 @@ INSERT INTO [dbo].[tbl_KirokuG2_Metric]
 ,[nvc_function]
 ,[i_type]
 ,[nvc_key]
-,[nvc_value])
+,[d_value])
 VALUES
 (@dt_session
 ,@nvc_id
@@ -28,6 +27,6 @@ VALUES
 ,@nvc_function
 ,@i_type
 ,@nvc_key
-,@nvc_value)
+,@d_value)
 
 END

--- a/KirokuG2/kirokug2-database/table/tbl_KirokuG2_Metric.sql
+++ b/KirokuG2/kirokug2-database/table/tbl_KirokuG2_Metric.sql
@@ -4,6 +4,6 @@ CREATE TABLE [dbo].[tbl_KirokuG2_Metric](
 	[nvc_source] [nvarchar](50) NULL,
 	[nvc_function] [nvarchar](50) NULL,
 	[i_type] [int] NULL,
-	[nvc_key] [nvarchar](20) NULL,
-	[nvc_value] [nvarchar](20) NULL
+	[nvc_key] [nvarchar](50) NULL,
+	[d_value] [decimal](10,2) NULL
 ) ON [PRIMARY]

--- a/KirokuG2/kirokug2-solution/KirokuG2.Internal.Loader.Test/Components/Utilities.cs
+++ b/KirokuG2/kirokug2-solution/KirokuG2.Internal.Loader.Test/Components/Utilities.cs
@@ -4,112 +4,112 @@ using KirokuG2.Loader;
 
 namespace KirokuG2.Internal.Loader.Test.Components
 {
-    public static class Utilities
-    {
-        public static void TestProcessor(Dictionary<string, string> logs, Dictionary<string, string> logTracker, Dictionary<string, string> sqlTracker, List<string> klogTracker)
-        {
-            MockLogProvider mockLogProvider = new(logs, logTracker);
+	public static class Utilities
+	{
+		public static void TestProcessor(Dictionary<string, string> logs, Dictionary<string, string> logTracker, Dictionary<string, string> sqlTracker, List<string> klogTracker)
+		{
+			MockLogProvider mockLogProvider = new(logs, logTracker);
 
-            MockSQLProvider mockSQLProvider = new(sqlTracker);
+			MockSQLProvider mockSQLProvider = new(sqlTracker);
 
-            KLoaderManager.Configuration(mockLogProvider, mockSQLProvider);
+			KLoaderManager.Configuration(mockLogProvider, mockSQLProvider);
 
-            MockKLog mockKLog = new MockKLog(klogTracker);
+			MockKLog mockKLog = new MockKLog(klogTracker);
 
-            KLoaderManager.ProcessLogs(mockKLog);
-        }
+			KLoaderManager.ProcessLogs(mockKLog);
+		}
 
-        public static bool CheckTrackerTypeCount(this Dictionary<string, string> tracker, string type, int count)
-        {
-            var itemCount = 0;
+		public static bool CheckTrackerTypeCount(this Dictionary<string, string> tracker, string type, int count)
+		{
+			var itemCount = 0;
 
-            foreach (var item in tracker)
-            {
-                var itemType = item.Key.Split("-")[1];
+			foreach (var item in tracker)
+			{
+				var itemType = item.Key.Split("-")[1];
 
-                if (string.Equals(type, itemType, StringComparison.OrdinalIgnoreCase))
-                {
-                    itemCount++;
-                }
-            }
+				if (string.Equals(type, itemType, StringComparison.OrdinalIgnoreCase))
+				{
+					itemCount++;
+				}
+			}
 
-            return itemCount == count;
-        }
+			return itemCount == count;
+		}
 
-        public static bool CheckTrackerContains(this Dictionary<string, string> tracker, string type, params string[] inputs)
-        {
-            foreach (var item in tracker)
-            {
-                var itemType = item.Key.Split("-")[1];
+		public static bool CheckTrackerContains(this Dictionary<string, string> tracker, string type, params string[] inputs)
+		{
+			foreach (var item in tracker)
+			{
+				var itemType = item.Key.Split("-")[1];
 
-                if (string.Equals(type, itemType, StringComparison.OrdinalIgnoreCase))
-                {
-                    var matchTotal = inputs.Length;
-                    var matchCount = 0;
-                    foreach (var input in inputs)
-                    {
-                        if (item.Value.Contains(input, StringComparison.OrdinalIgnoreCase))
-                        {
-                            matchCount++;
-                        }
-                    }
+				if (string.Equals(type, itemType, StringComparison.OrdinalIgnoreCase))
+				{
+					var matchTotal = inputs.Length;
+					var matchCount = 0;
+					foreach (var input in inputs)
+					{
+						if (item.Value.Contains(input, StringComparison.OrdinalIgnoreCase))
+						{
+							matchCount++;
+						}
+					}
 
-                    if (matchCount == matchTotal)
-                    {
-                        return true;
-                    }
-                }
-            }
+					if (matchCount == matchTotal)
+					{
+						return true;
+					}
+				}
+			}
 
-            return false;
-        }
+			return false;
+		}
 
-        public static bool CheckTrackContains(this Dictionary<string, List<string>> tracker, string key, params string[] inputs)
-        {
-            if (tracker.TryGetValue(key, out var value))
-            {
-                foreach (var input in inputs)
-                {
-                    if (!value.Contains(input))
-                    {
-                        return false;
-                    }
-                }
-            }
-            else
-            {
-                return false;
-            }
+		public static bool CheckTrackContains(this Dictionary<string, List<string>> tracker, string key, params string[] inputs)
+		{
+			if (tracker.TryGetValue(key, out var value))
+			{
+				foreach (var input in inputs)
+				{
+					if (!value.Contains(input))
+					{
+						return false;
+					}
+				}
+			}
+			else
+			{
+				return false;
+			}
 
-            return true;
-        }
+			return true;
+		}
 
-        public static bool CheckTrackerContains(this List<string> tracker, params string[] inputs)
-        {
-            foreach (var record in tracker)
-            {
+		public static bool CheckTrackerContains(this List<string> tracker, params string[] inputs)
+		{
+			foreach (var record in tracker)
+			{
 				var missing = false;
 
 				foreach (var input in inputs)
-                {
-                    if (missing)
-                    {
-                        break;
-                    }
-                    else
-                    {
-                        if (!record.Contains(input, StringComparison.OrdinalIgnoreCase))
-                        {
-                            missing = true;
-                            break;
-                        }
-                    }
+				{
+					if (missing)
+					{
+						break;
+					}
+					else
+					{
+						if (!record.Contains(input, StringComparison.OrdinalIgnoreCase))
+						{
+							missing = true;
+							break;
+						}
+					}
 
-                    return true;
-                }
-            }
+					return true;
+				}
+			}
 
-            return false;
-        }
-    }
+			return false;
+		}
+	}
 }

--- a/KirokuG2/kirokug2-solution/KirokuG2.Internal.Loader.Test/Components/Utilities.cs
+++ b/KirokuG2/kirokug2-solution/KirokuG2.Internal.Loader.Test/Components/Utilities.cs
@@ -83,5 +83,33 @@ namespace KirokuG2.Internal.Loader.Test.Components
 
             return true;
         }
+
+        public static bool CheckTrackerContains(this List<string> tracker, params string[] inputs)
+        {
+            foreach (var record in tracker)
+            {
+				var missing = false;
+
+				foreach (var input in inputs)
+                {
+                    if (missing)
+                    {
+                        break;
+                    }
+                    else
+                    {
+                        if (!record.Contains(input, StringComparison.OrdinalIgnoreCase))
+                        {
+                            missing = true;
+                            break;
+                        }
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/KirokuG2/kirokug2-solution/KirokuG2.Internal.Loader.Test/Data/ExampleKLogs.cs
+++ b/KirokuG2/kirokug2-solution/KirokuG2.Internal.Loader.Test/Data/ExampleKLogs.cs
@@ -99,5 +99,48 @@
 				"2024-04-14T03:34:59.9913758Z,E,tes,ting er,ror\r\n" +
 				"2024-04-14T03:34:59.9913762Z,SI,0";
 		}
+
+		// metrics
+		public static string MetricInstanceLog()
+		{
+			return "2024-04-14T03:34:59.9913558Z,I,test-kiroku-injektr-wus3$Kiroku-Audit\r\n" +
+
+				// pass positive
+				"2024-04-14T03:34:59.9913675Z,M,2$test metric01$1\r\n" + // 1
+				"2024-04-14T03:34:59.9913729Z,M,2$test metric02$1.0\r\n" + // 1.0
+				"2024-04-14T03:34:59.9913675Z,M,2$test metric03$0123456789\r\n" + // 0123456789
+				"2024-04-14T03:34:59.9913675Z,M,2$test metric04$.01\r\n" + // .01
+				"2024-04-14T03:34:59.9913675Z,M,2$test metric05$0.02\r\n" + // 0.02
+				"2024-04-14T03:34:59.9913675Z,M,2$test metric06$0123456789.01\r\n" + // 0123456789.01
+
+				// pass negative
+				"2024-04-14T03:34:59.9913675Z,M,2$test metric07$-1\r\n" + // -1
+				"2024-04-14T03:34:59.9913729Z,M,2$test metric08$-1.0\r\n" + // -1.0
+				"2024-04-14T03:34:59.9913675Z,M,2$test metric09$-0123456789\r\n" + // -0123456789
+				"2024-04-14T03:34:59.9913675Z,M,2$test metric10$-.01\r\n" + // -.01
+				"2024-04-14T03:34:59.9913675Z,M,2$test metric11$-0.02\r\n" + // -0.02
+				"2024-04-14T03:34:59.9913675Z,M,2$test metric12$-0123456789.01\r\n" + // -0123456789.01
+
+				// fail positive
+				"2024-04-14T03:34:59.9913675Z,M,2$test metric13$12345678910\r\n" + // 11 digit whole - fail
+				"2024-04-14T03:34:59.9913729Z,M,2$test metric14$12345678910.12\r\n" + // 11 digit left - fail
+				"2024-04-14T03:34:59.9913729Z,M,2$test metric15$1234567891.123\r\n" + // 3 digit right - fail
+				"2024-04-14T03:34:59.9913729Z,M,2$test metric16$12345678910.123\r\n" + // 3 digit right - fail
+
+				// fail negative
+				"2024-04-14T03:34:59.9913675Z,M,2$test metric17$-12345678910\r\n" + // 11 digit whole - fail
+				"2024-04-14T03:34:59.9913729Z,M,2$test metric18$-12345678910.12\r\n" + // 11 digit left - fail
+				"2024-04-14T03:34:59.9913729Z,M,2$test metric19$-1234567891.123\r\n" + // 3 digit right - fail
+				"2024-04-14T03:34:59.9913729Z,M,2$test metric20$-12345678910.123\r\n" + // 3 digit right - fail
+
+				// fail
+				"2024-04-14T03:34:59.9913738Z,M,2$test metric21$test\r\n" + // string - fail
+				"2024-04-14T03:34:59.9913584Z,M,2$test metric22$\r\n" + // null
+
+				// dup check, pass
+				"2024-04-14T03:34:59.9913745Z,M,2$test metric1$1\r\n" + // same metric name
+
+				"2024-04-14T03:34:59.9913762Z,SI,0";
+		}
 	}
 }

--- a/KirokuG2/kirokug2-solution/KirokuG2.Internal.Loader.Test/Tests/EdgeCases.cs
+++ b/KirokuG2/kirokug2-solution/KirokuG2.Internal.Loader.Test/Tests/EdgeCases.cs
@@ -3,7 +3,7 @@ using KirokuG2.Internal.Loader.Test.Data;
 
 namespace KirokuG2.Internal.Loader.Test.Tests
 {
-    [TestClass]
+	[TestClass]
 	public class EdgeCases
 	{
 		[TestMethod]

--- a/KirokuG2/kirokug2-solution/KirokuG2.Internal.Loader.Test/Tests/Index.cs
+++ b/KirokuG2/kirokug2-solution/KirokuG2.Internal.Loader.Test/Tests/Index.cs
@@ -1,8 +1,6 @@
 using KirokuG2.Internal.Loader.Components;
 using KirokuG2.Internal.Loader.Test.Components;
 using KirokuG2.Internal.Loader.Test.Data;
-using Microsoft.Identity.Client;
-using NuGet.Frameworks;
 using System.Text;
 
 namespace KirokuG2.Internal.Loader.Test.Tests

--- a/KirokuG2/kirokug2-solution/KirokuG2.Internal.Loader/Components/Internal/InsertMetricOperation.cs
+++ b/KirokuG2/kirokug2-solution/KirokuG2.Internal.Loader/Components/Internal/InsertMetricOperation.cs
@@ -18,7 +18,7 @@ namespace KirokuG2.Loader.Components.Internal
 				cmd.Parameters.AddWithValue("nvc_function", logMetric.Function);
 				cmd.Parameters.AddWithValue("i_type", logMetric.Type);
 				cmd.Parameters.AddWithValue("nvc_key", logMetric.Key);
-				cmd.Parameters.AddWithValue("nvc_value", logMetric.Value);
+				cmd.Parameters.AddWithValue("d_value", logMetric.Value);
 
 				cmd.CommandTimeout = 0;
 

--- a/KirokuG2/kirokug2-solution/KirokuG2.Internal.Loader/KLoaderManager.cs
+++ b/KirokuG2/kirokug2-solution/KirokuG2.Internal.Loader/KLoaderManager.cs
@@ -159,18 +159,47 @@
 									var key = metric_components[1];
 									var value = metric_components[2];
 
-									LogMetric logMetric = new LogMetric
+									if (string.IsNullOrEmpty(value))
 									{
-										Timestamp = datetime,
-										Source = source,
-										Function = function,
-										Id = instance,
-										Type = metric_type,
-										Key = key,
-										Value = value
-									};
+										klog.Error($"Instance: {instance} | Metric is empty -> {key}");
+									}
+									else
+									{
+										if (Decimal.TryParse(value, out var metricValue))
+										{
+											var parts = value.Split('.');
+											var partOne = parts[0].Replace("-", "");
+											var partTwo = parts.Length == 2 ? parts[1].Replace("-", "") : string.Empty;
 
-									logMetrics.Add(logMetric);
+											if (partOne.Length > 10)
+											{
+												klog.Error($"Instance: {instance} | Metric has invalid format on part one-> {key} = {value}");
+											}
+											else if (!string.IsNullOrEmpty(partTwo) && partTwo.Length > 2)
+											{
+												klog.Error($"Instance: {instance} | Metric has invalid format on part two -> {key} = {value}");
+											}
+											else
+											{
+												LogMetric logMetric = new LogMetric
+												{
+													Timestamp = datetime,
+													Source = source,
+													Function = function,
+													Id = instance,
+													Type = metric_type,
+													Key = key,
+													Value = metricValue
+												};
+
+												logMetrics.Add(logMetric);
+											}
+										}
+										else
+										{
+											klog.Error($"Instance: {instance} | Metric failed to parse -> {key} = {value}");
+										}
+									}
 								}
 
 								// activation

--- a/KirokuG2/kirokug2-solution/KirokuG2.Internal.Loader/Models/LogMetric.cs
+++ b/KirokuG2/kirokug2-solution/KirokuG2.Internal.Loader/Models/LogMetric.cs
@@ -14,6 +14,6 @@
 
 		public string Key { get; set; }
 
-		public string Value { get; set; }
+		public decimal Value { get; set; }
 	}
 }


### PR DESCRIPTION
### Polaris-2

**Refactor Metrics**

- Support only Numbers
   - Remove support for string and other value types
- Continue to store number type; int, double, etc.
- Store value as decimal(10,2) in SQL